### PR TITLE
accept the version ranges properties

### DIFF
--- a/src/main/java/cc/notsoclever/tools/Versions.java
+++ b/src/main/java/cc/notsoclever/tools/Versions.java
@@ -44,7 +44,7 @@ public class Versions {
     public static final String POM2_TRUNK_URL = "https://raw.github.com/{0}/{1}/{2}/pom.xml";
     public static final String TAGS_URL = "https://api.github.com/repos/{0}/{1}/tags";
 
-    private static final Pattern VERSION_PROP_REGEX = Pattern.compile("^(.*).version$");
+    private static final Pattern VERSION_PROP_REGEX = Pattern.compile("^(.*).version(.range)?$");
     private static final Pattern VERSION_VALUE_REGEX = Pattern.compile("^[\\(\\[]?\\d[0-9A-Za-z\\-\\.\\,\\s]*[\\)\\]]?$");
     private static final String DEFAULT_ORG = "apache";
     private static final String DEFAULT_NAME = "camel";
@@ -224,7 +224,12 @@ public class Versions {
                 String nodeValue = node.getChildNodes().item(0).getNodeValue();
                 Matcher mv = VERSION_VALUE_REGEX.matcher(nodeValue);
                 if (mv.find()) {
-                    versions.put(mp.group(1), nodeValue);
+                    if (mp.group(2) != null) {
+                        // including the version range suffix
+                        versions.put(mp.group(1) + mp.group(2), nodeValue);
+                    } else {
+                        versions.put(mp.group(1), nodeValue);
+                    }
                 }
             }
         }

--- a/src/test/java/cc/notsoclever/tools/VersionsTest.java
+++ b/src/test/java/cc/notsoclever/tools/VersionsTest.java
@@ -97,8 +97,8 @@ public class VersionsTest extends Assert {
     
     Map<String, String> unchanged = versions.getUnChanged();
     assertNotNull(unchanged);
-    assertEquals(249, unchanged.size());
-    assertEquals(249, versions.getTotal() - 4 - 27);
+    assertEquals(251, unchanged.size());
+    assertEquals(251, versions.getTotal() - 4 - 27);
   }
 
   @Test
@@ -129,8 +129,8 @@ public class VersionsTest extends Assert {
     
     Map<String, String> unchanged = versions.getUnChanged();
     assertNotNull(unchanged);
-    assertEquals(76, unchanged.size());
-    assertEquals(76, versions.getTotal() - 1 - 8);
+    assertEquals(79, unchanged.size());
+    assertEquals(79, versions.getTotal() - 1 - 8);
   }
   
   @Test
@@ -161,8 +161,8 @@ public class VersionsTest extends Assert {
     
     Map<String, String> unchanged = versions.getUnChanged();
     assertNotNull(unchanged);
-    assertEquals(32, unchanged.size());
-    assertEquals(32, versions.getTotal() - 3);
+    assertEquals(33, unchanged.size());
+    assertEquals(33, versions.getTotal() - 3);
   }
   
   @Test


### PR DESCRIPTION
Hi Tracy,
I added the handling of the range suffix. Both cxf and camel use either name.version.range or name-version-range to define the corresponding osgi version ranges. Currently, these properties are not included in the list. I modified the regex so that they are also picked up.

Could you include this change?
Thanks.
regards, aki
